### PR TITLE
Caddyfile support

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -1,11 +1,8 @@
 package caddy2proxyprotocol
 
-import "github.com/caddyserver/caddy/v2"
-
-var (
-	_ = caddy.Provisioner(&Wrapper{})
-	_ = caddy.Module(&Wrapper{})
-	_ = caddy.ListenerWrapper(&Wrapper{})
+import (
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 )
 
 func init() {
@@ -18,3 +15,47 @@ func (Wrapper) CaddyModule() caddy.ModuleInfo {
 		New: func() caddy.Module { return new(Wrapper) },
 	}
 }
+
+// UnmarshalCaddyfile sets up the listener wrapper from Caddyfile tokens. Syntax:
+//
+//     proxy_protocol {
+//         timeout <duration>
+//         allow <IPs...>
+//     }
+//
+func (w *Wrapper) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	for d.Next() {
+		// No same-line options are supported
+		if d.NextArg() {
+			return d.ArgErr()
+		}
+
+		for d.NextBlock(0) {
+			switch d.Val() {
+			case "timeout":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+				dur, err := caddy.ParseDuration(d.Val())
+				if err != nil {
+					return d.Errf("parsing proxy_protocol timeout duration: %v", err)
+				}
+				w.Timeout = caddy.Duration(dur)
+
+			case "allow":
+				w.Allow = append(w.Allow, d.RemainingArgs()...)
+
+			default:
+				return d.ArgErr()
+			}
+		}
+	}
+	return nil
+}
+
+var (
+	_ caddy.Provisioner     = (*Wrapper)(nil)
+	_ caddy.Module          = (*Wrapper)(nil)
+	_ caddy.ListenerWrapper = (*Wrapper)(nil)
+	_ caddyfile.Unmarshaler = (*Wrapper)(nil)
+)


### PR DESCRIPTION
FYI @mholt, @JackEllis

Closes #1 

```
{
	servers {
		listener_wrappers {
			proxy_protocol {
				timeout 2s
				allow 0.0.0.0/0 1.2.3.4/0
			}
			tls
		}
	}
}

foo.com {
}
```

This is now possible since https://github.com/caddyserver/caddy/pull/3836 is merged.

~~I haven't tested this yet, slight issue with `xcaddy` preventing me from compiling, but @mholt is looking into it.~~

Tested, the above Caddyfile gives this JSON:

```json
{
	"apps": {
		"http": {
			"servers": {
				"srv0": {
					"listen": [
						":443"
					],
					"listener_wrappers": [
						{
							"allow": [
								"0.0.0.0/0",
								"1.2.3.4/0"
							],
							"timeout": 2000000000,
							"wrapper": "proxy_protocol"
						},
						{
							"wrapper": "tls"
						}
					],
					"routes": [
						{
							"match": [
								{
									"host": [
										"foo.com"
									]
								}
							],
							"terminal": true
						}
					]
				}
			}
		}
	}
}
```

Ready to go!